### PR TITLE
Data profiling update

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -4,7 +4,7 @@ import io
 
 import pypdf
 
-from typing import List
+from typing import List, Optional
 
 from fastapi import FastAPI, Response, status, UploadFile, File
 from fastapi.middleware.cors import CORSMiddleware
@@ -111,22 +111,7 @@ async def pdf_extractions(
 
 
 @app.post("/profile_dataset/{dataset_id}")
-def profile_dataset_document(dataset_id: str):
-    from utils import create_job
-
-    operation_name = "operations.dataset_profiling"
-
-    options = {
-        "dataset_id": dataset_id,
-    }
-
-    resp = create_job(operation_name=operation_name, options=options)
-
-    return resp
-
-
-@app.post("/profile_dataset/{dataset_id}/{artifact_id}")
-def profile_dataset_document(dataset_id: str, artifact_id: str = None):
+def profile_dataset_document(dataset_id: str, artifact_id: Optional[str] = None):
     from utils import create_job
 
     operation_name = "operations.dataset_profiling_with_document"

--- a/api/server.py
+++ b/api/server.py
@@ -111,7 +111,17 @@ async def pdf_extractions(
 
 
 @app.post("/profile_dataset/{dataset_id}")
-def profile_dataset_document(dataset_id: str, artifact_id: Optional[str] = None):
+def profile_dataset(dataset_id: str, artifact_id: Optional[str] = None):
+    """Profile dataset with MIT's profiling service. This optionally accepts an `artifact_id` which 
+    is expected to be some user uploaded document which has had its text extracted and stored to 
+    `metadata.text`.
+
+    > NOTE: if nothing is found within `metadata.text` of the artifact then it is ignored.
+
+    Args:
+        dataset_id: the id of the dataset to profile
+        artifact_id [optional]: the id of the artifact (paper/document) associated with the dataset.
+    """    
     from utils import create_job
 
     operation_name = "operations.dataset_profiling_with_document"

--- a/workers/utils.py
+++ b/workers/utils.py
@@ -126,6 +126,6 @@ def get_dataset_from_tds(dataset_id):
     else:
         final_df = dataframes[0]
 
-    csv_string = final_df.to_csv()
+    csv_string = final_df.to_csv(index=False)
 
     return dataset, final_df, csv_string


### PR DESCRIPTION
* consolidates data profiling to one endpoint
* endpoint optionally accepts an `artifact_id`
* if no `artifact_id` is provided MIT is told there is no documentation for the dataset
* if an `artifact_id` is provided, the expectation is that the `metadata.text` of that artifact contains the extracted text from either the publication or from the document, etc.

> NOTE: this last point is crucial--we are no longer going to send in raw PDF or a raw text file to MIT. If nothing is there, it defaults to just empty basically.