### PR TITLE
Use new cosmos endpoint for text results

### DIFF
--- a/lib/settings.py
+++ b/lib/settings.py
@@ -31,7 +31,7 @@ class Settings(BaseSettings):
     TDS_URL: str = "http://data-service.staging.terarium.ai:8000"
     TDS_USER: str = "user"
     TDS_PASSWORD: str = "password"
-    COSMOS_URL: str = "http://xdd.wisc.edu/cosmos_service"
+    COSMOS_URL: str = "http://cosmos0004.chtc.wisc.edu:8088"
     OPENAI_API_KEY: str = "foo"
     LOG_LEVEL: str = "INFO"
     PDF_EXTRACTOR: ExtractionServices = "cosmos"

--- a/worker/operations.py
+++ b/worker/operations.py
@@ -166,7 +166,7 @@ def cosmos_extraction(document_id, filename, downloaded_document, force_run=Fals
         logger.info("COSMOS response object: %s", extraction_json)
         status_endpoint = extraction_json["status_endpoint"]
         result_endpoint = f"{extraction_json['result_endpoint']}"
-        result_endpoint_text = f"{result_endpoint}/text"
+        result_endpoint_text = f"{result_endpoint}/text-layer"
         equations_endpoint = f"{result_endpoint}/extractions/equations"
         figures_endpoint = f"{result_endpoint}/extractions/figures"
         tables_endpoint = f"{result_endpoint}/extractions/tables"


### PR DESCRIPTION
# Description

* @iross provided a new endpoint to retreive text of a document including the dataset inlined within.
* Waiting on xDD to help me fix that test issue.
